### PR TITLE
Fix deprecated launch options type

### DIFF
--- a/AppWeather/AppDelegate.swift
+++ b/AppWeather/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
## Summary
- update deprecated `UIApplicationLaunchOptionsKey` to `UIApplication.LaunchOptionsKey`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68644ba36524832f8deff0f6c40e7798